### PR TITLE
Fixed incorrect variable reference - $tplx does not exist

### DIFF
--- a/evlist_views.inc.php
+++ b/evlist_views.inc.php
@@ -847,7 +847,7 @@ function EVLIST_monthview($year=0, $month=0, $day=0, $cat=0, $cal=0, $opt='')
                 'urlfilt_cat' => $cat,
                 'urlfilt_cal' => $cal,
                 'weeknum' => $weekOfYear,
-                $tplx => 'true',
+                $tpl => 'true',
         ) );
         $weekOfYear++;
 

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -233,7 +233,7 @@ default:
     break;
 }
 
-$display = EVLIST_siteHeader($LANG_EVLIST['pi_title']);
+$display = EVLIST_siteHeader($LANG_EVLIST['pi_name']);
 if (!empty($msg)) {
     //msg block
     $display .= COM_startBlock('','','blockheader-message.thtml');

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -233,7 +233,7 @@ default:
     break;
 }
 
-$display = EVLIST_siteHeader($LANG_EVLIST['pi_name']);
+$display = EVLIST_siteHeader($LANG_EVLIST['pi_title']);
 if (!empty($msg)) {
     //msg block
     $display .= COM_startBlock('','','blockheader-message.thtml');


### PR DESCRIPTION
The variable $tplx does not exist and could not be found anywhere else in the code. It appears this reference should be $tpl to set the template type and allow for {!if } processing.